### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/Unixutils.cabal
+++ b/Unixutils.cabal
@@ -11,7 +11,7 @@ Description:
  A collection of useful and mildly useful functions that you might
  expect to find in System.* which a heavy bias towards Unix-type operating systems.
 Build-type:	Simple
-Cabal-Version: >= 1.2
+Cabal-Version: >= 1.8
 
 Library
     Build-Depends:


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: Unixutils.cabal:18:19: version operators used. To use version       
operators the package needs to specify at least 'cabal-version: >= 1.8'.                                                                                                                                                                                                           
```